### PR TITLE
Add filetype information parsing from kk:file fields

### DIFF
--- a/src/transform/convert/common/generate0xx.js
+++ b/src/transform/convert/common/generate0xx.js
@@ -3,16 +3,17 @@ import {formatLanguage, getHandle} from '../util';
 /**
  * Generates field 020 ($a, $q) based on dc.identifier.isbn values
  * @param {Object} ValueInterface containing getFieldValues function
+ * @param {string} filetype - filetype of record that is mapped to f020 $q
  * @returns Empty array or array containing field(s) 020
  */
-export function generate020({getFieldValues}) {
+export function generate020({getFieldValues}, filetype = 'PDF') {
   const values = getFieldValues('dc.identifier.isbn');
   return values.map(value => {
     return {
       tag: '020', ind1: '', ind2: '',
       subfields: [
         {code: 'a', value: formatValue()},
-        {code: 'q', value: 'PDF'}
+        {code: 'q', value: filetype}
       ]
     };
 

--- a/src/transform/convert/index.js
+++ b/src/transform/convert/index.js
@@ -20,11 +20,12 @@ import {getLanguage} from './util';
  * @param {object} conversionConfig Config object containing following attributes:
  * - harvestSource Source where record was harvested from
  * - fieldValueInterface interface containing getFieldValues and getFields functions
+ * - filetype o
  * - convertOpts Options to control conversion (e.g., moment mock for automated tests)
  * - numberOfFiles represents number of kk:file tags within the record metadata
  * @return Newly generated MarcRecord object
  */
-export default ({harvestSource, fieldValueInterface, convertOpts = {}, numberOfFiles = 1}) => {
+export default ({harvestSource, fieldValueInterface, filetype, convertOpts = {}, numberOfFiles = 1}) => {
   const momentSource = convertOpts.moment || moment;
   const titleLanguage = getLanguage(fieldValueInterface);
 
@@ -34,7 +35,7 @@ export default ({harvestSource, fieldValueInterface, convertOpts = {}, numberOfF
   const fields = [
     generate007(),
     generate008(fieldValueInterface, titleLanguage, momentSource),
-    generate020(fieldValueInterface),
+    generate020(fieldValueInterface, filetype),
     generate024(fieldValueInterface),
     generate040(),
     generate041(fieldValueInterface),

--- a/src/transform/convert/util/index.js
+++ b/src/transform/convert/util/index.js
@@ -63,6 +63,34 @@ export function getInputFields(record) {
 }
 
 /**
+ * Getter for filetype information from kk:file tag of the record. Defaults to PDF if no valid filetype cannot be found.
+ * @param {Object} record - record to process
+ * @returns {string} filetype information in format that may be used in f020 $q. Defaults to PDF if no valid filetype can be found.
+ */
+export function getRecordFiletype(record) {
+  const filetypeMappingTable = {
+    'application/pdf': 'PDF',
+    'text/html': 'HTML',
+    'audio/mp3': 'MP3'
+  };
+
+  const validFiletypeDefinitions = Object.keys(filetypeMappingTable);
+  const defaultFiletype = 'application/pdf';
+
+  const recordFiletypeFields = record['kk:file'];
+  if (!recordFiletypeFields) {
+    return filetypeMappingTable[defaultFiletype];
+  }
+
+  const recordFiletype = record['kk:file']
+    .filter(field => '$' in field && field.$.type) // Filter entries who do not have mandatory field
+    .find(field => validFiletypeDefinitions.includes(field.$.type));
+
+  const selectedFiletype = recordFiletype ? recordFiletype.$.type : defaultFiletype;
+  return filetypeMappingTable[selectedFiletype];
+}
+
+/**
  * Parses source and handle from dc.identifier.uri values or from header information
  * @param {string} value URI value
  * @returns false if source or handle cannot be parsed, otherwise object containing source and handle attributes

--- a/src/transform/filter/index.js
+++ b/src/transform/filter/index.js
@@ -1,7 +1,7 @@
 import createDebugLogger from 'debug';
 
 import {generateSID} from '../convert/common/generateSystemFields';
-import {getInputFields, createValueInterface} from '../convert/util';
+import {getInputFields, createValueInterface, getRecordFiletype} from '../convert/util';
 
 import {filterByFileType} from './filterByFileType';
 import {filterByIsbnIdentifier} from './filterByIsbnIdentifier';
@@ -23,7 +23,6 @@ export default (harvestSource, record, applyFilters = [], filterConfig = {}) => 
   const inputFields = getInputFields(record);
   const fieldValueInterface = createValueInterface(inputFields);
   const {getFieldValues} = fieldValueInterface;
-
 
   // Information required for filtering records
   const titleValues = getFieldValues('dc.title');
@@ -64,8 +63,12 @@ export default (harvestSource, record, applyFilters = [], filterConfig = {}) => 
   selectedFilters.raw.forEach(f => f.filter(record, debugInfo));
   selectedFilters.interface.forEach(f => f.filter(fieldValueInterface, debugInfo));
 
+  // Parse filetype. Note that this should not be done before applying filters since records without kk:file-tag may also be filtered.
+  const filetype = getRecordFiletype(record);
+
   return {
     fieldValueInterface,
+    filetype,
     commonErrorPayload: {title, identifiers}
   };
 };

--- a/src/transform/filter/index.spec.js
+++ b/src/transform/filter/index.spec.js
@@ -55,7 +55,7 @@ function callback({getFixture, filter, filterConfig = {}}) {
 
     // NB: filters should not result into halting errors
     // eslint-disable-next-line handle-callback-err, no-unused-vars
-    function handleError(_) {
+    function handleError(_err) {
       expect(1).to.equal(0);
     }
   });

--- a/src/transform/index.js
+++ b/src/transform/index.js
@@ -92,9 +92,9 @@ export default convertOpts => (stream, {validate = true, fix = true} = {}) => {
             throw new ConversionError({}, `Cannot find conversion configuration for the following harvest source or config is missing at least one of mandatory keys: ${harvestSource}`);
           }
 
-          const {fieldValueInterface, commonErrorPayload} = filterAndCreateValueInterface(harvestSource, recordMetadata, applyFilters, filterConfig);
+          const {fieldValueInterface, filetype, commonErrorPayload} = filterAndCreateValueInterface(harvestSource, recordMetadata, applyFilters, filterConfig);
           const numberOfFiles = getAllValuesInContext(recordMetadata, 'kk:file').length;
-          const convertedRecord = convertRecord({harvestSource, fieldValueInterface, convertOpts, numberOfFiles});
+          const convertedRecord = convertRecord({harvestSource, filetype, fieldValueInterface, convertOpts, numberOfFiles});
 
           if (validate === true || fix === true) {
             const validateFixResult = await validateRecord(convertedRecord, fix, validate);

--- a/test-fixtures/transform/integration/01/input.xml
+++ b/test-fixtures/transform/integration/01/input.xml
@@ -44,8 +44,8 @@
             value="&lt;&quot;Cool Stuff&quot;, like &apos;this&apos;: Dublin Core &amp; MARC21 &hearts; &gt;" />
           <kk:field schema="dc" element="type" language="fi" value="sarjajulkaisu" />
           <kk:file bundle="ORIGINAL"
-            href="https://foobar.example.com/bitstream/123/456/1/example.pdf"
-            name="example.pdf" type="application/pdf" />
+            href="https://foobar.example.com/bitstream/123/456/1/example.html"
+            name="example.html" type="text/html" />
         </kk:metadata>
       </metadata>
     </record>

--- a/test-fixtures/transform/integration/01/metadata.json
+++ b/test-fixtures/transform/integration/01/metadata.json
@@ -1,5 +1,5 @@
 {
-  "description": "Transformation successfully completes (incl. hash)",
+  "description": "Transformation successfully completes (incl. hash and filetype)",
   "testHash": true,
   "only": false
 }

--- a/test-fixtures/transform/integration/01/output.json
+++ b/test-fixtures/transform/integration/01/output.json
@@ -21,7 +21,7 @@
           },
           {
             "code": "q",
-            "value": "PDF"
+            "value": "HTML"
           }
         ]
       },
@@ -413,7 +413,7 @@
           },
           {
             "code": "k",
-            "value": "MELINDA_RECORD_IMPORT_REPO:FOOBAR:bca9390abe71e65dad7b9c7b2a6a4655c043a412de978e333d04069d54dd13c6"
+            "value": "MELINDA_RECORD_IMPORT_REPO:FOOBAR:32ea80b4d56267a55ae658c0cad207c1b414bc014c83b4cdaedce8117fd6aa52"
           },
           {
             "code": "q",


### PR DESCRIPTION
- Add filetype parsing from kk:file fields. Defaults to PDF if no tag can be found (note that if using filetype validator these records will not be generated)
- Adds usage of filetype information to f020 $q in case it's provided