### PR TITLE
Fix phrasing in f300 $e

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,12 +26,13 @@
 		"build": "babel src --source-maps --copy-files --delete-dir-on-start --out-dir=dist",
 		"lint": "eslint ./src",
 		"lint:dev": "eslint --fix ./src",
-		"test": "npm run lint && npm run test:base -- \"./src/**/*.spec.js\"",
-		"test:base": "cross-env NODE_ENV=test nyc --reporter=text mocha --reporter-option maxDiffSize=25000 --require @babel/register",
+		"test": "npm run lint && npm run test:nyc -- \"./src/**/*.spec.js\"",
+		"test:base": "cross-env NODE_ENV=test mocha --reporter-option maxDiffSize=25000 --require @babel/register",
+		"test:nyc": "cross-env NODE_ENV=test nyc --reporter=text mocha --reporter-option maxDiffSize=25000 --require @babel/register",
 		"coverage": "npm run cover:unit && npm run cover:report",
 		"cover:unit": "nyc --silent npm run test:base",
 		"cover:report": "nyc report",
-		"watch:test": "cross-env DEBUG=1 NODE_ENV=test nodemon -e js,xml -w src -w test-fixtures --exec 'npm run test:base -- -b \"./src/**/*.spec.js\"'"
+		"watch:test": "cross-env NODE_ENV=test nodemon -e js,xml -w src -w test-fixtures --exec 'npm run test:base -- -b \"./src/**/*.spec.js\"'"
 	},
 	"dependencies": {
 		"@natlibfi/marc-record": "^9.0.1",

--- a/src/transform/convert/common/generate3xx.js
+++ b/src/transform/convert/common/generate3xx.js
@@ -7,9 +7,9 @@
 export function generate300({getFieldValues}, numberOfFiles) {
   const [value] = getFieldValues('dc.format.extent');
 
-  const numberOfAttachments = numberOfFiles && numberOfFiles > 1 ? numberOfFiles - 1 : 0;
+  const numberOfAttachments = numberOfFiles && numberOfFiles > 1 ? numberOfFiles - 1 : 0; // NB: when there are two files, there is one attachment
   const subfieldA = value ? [{code: 'a', value: `1 verkkoaineisto (${value} sivua)`}] : [{code: 'a', value: '1 verkkoaineisto'}];
-  const subfieldE = numberOfAttachments > 0 ? [{code: 'e', value: `${numberOfAttachments} liitettä`}] : [];
+  const subfieldE = numberOfAttachments > 0 ? getSubfieldE(numberOfAttachments) : [];
 
   const subfields = [...subfieldA, ...subfieldE];
 
@@ -19,6 +19,11 @@ export function generate300({getFieldValues}, numberOfFiles) {
       subfields
     }
   ];
+
+
+  function getSubfieldE(numberOfAttachments) {
+    return numberOfAttachments > 1 ? [{code: 'e', value: `${numberOfAttachments} liitettä`}] : [{code: 'e', value: '1 liite'}];
+  }
 }
 
 /**

--- a/test-fixtures/transform/convert/common/generate3xx/generate300/04/input.json
+++ b/test-fixtures/transform/convert/common/generate3xx/generate300/04/input.json
@@ -1,0 +1,10 @@
+[
+  {
+    "$": {
+      "schema": "dc",
+      "element": "format",
+      "qualifier": "extent",
+      "value": "123"
+    }
+  }
+]

--- a/test-fixtures/transform/convert/common/generate3xx/generate300/04/metadata.json
+++ b/test-fixtures/transform/convert/common/generate3xx/generate300/04/metadata.json
@@ -1,0 +1,5 @@
+{
+  "description": "Generates $e with correct phrasing if number of files is exactly two (which translates to main file + one attachment)",
+  "numberOfFiles": 2,
+  "only": true
+}

--- a/test-fixtures/transform/convert/common/generate3xx/generate300/04/output.json
+++ b/test-fixtures/transform/convert/common/generate3xx/generate300/04/output.json
@@ -1,0 +1,9 @@
+[
+  {
+    "tag": "300", "ind1": "", "ind2": "",
+    "subfields": [
+      {"code": "a", "value": "1 verkkoaineisto (123 sivua)"},
+      {"code": "e", "value": "1 liite"}
+    ]
+  }
+]


### PR DESCRIPTION
* Having exactly one attachment produces now correct Finnish phrase for f300 $e
* Development nodemon command no more includes nyc reporting information