### PR TITLE
Refactor and adjust f341 accessibility map

### DIFF
--- a/src/transform/convert/common/generate3xx.js
+++ b/src/transform/convert/common/generate3xx.js
@@ -1,3 +1,5 @@
+import {getAccessibilityFieldInfo} from '../util/accessibility-feature-map.js';
+
 /**
  * Generates field 300 ($a) based on first dc.format.extent value.
  * @param {Object} ValueInterface containing getFieldValues function
@@ -87,115 +89,47 @@ export function generate338() {
  * @returns {import('../../../types.js').DataField[]}
  */
 export function generate341({getFieldValues}) {
-  // Mapping is in process and may be expanded in future.
-  // 'looginen lukemisjärjestys' and 'taulukot saavutettavia' do have equal mapping by design
-  // unknown accessibility has language versions with equal mapping by design
-  const accessibilityFeatureMap = {
-    'navigointi mahdollista': {
-      ind1: '0',
-      subfieldA: 'textual',
-      subfieldB: 'structuralNavigation',
-      subfield2: 'sapdv'
-    },
-    'kuvilla vaihtoehtoiset kuvaukset': {
-      ind1: '0',
-      subfieldA: 'visual',
-      subfieldB: 'alternativeText',
-      subfield2: 'sapdv'
-    },
-    'looginen lukemisjärjestys': {
-      ind1: '0',
-      subfieldA: 'textual',
-      subfieldB: 'readingOrder',
-      subfield2: 'sapdv'
-    },
-    'taulukot saavutettavia': {
-      ind1: '0',
-      subfieldA: 'textual',
-      subfieldB: 'readingOrder',
-      subfield2: 'sapdv'
-    },
-    'ei tietoa saavutettavuudesta': {
-      ind1: '0',
-      subfieldA: 'textual',
-      subfieldB: 'unknown',
-      subfield2: 'sapdv'
-    },
-    'okänd tillgänglighet': {
-      ind1: '0',
-      subfieldA: 'textual',
-      subfieldB: 'unknown',
-      subfield2: 'sapdv'
-    },
-    'unknown accessibility': {
-      ind1: '0',
-      subfieldA: 'textual',
-      subfieldB: 'unknown',
-      subfield2: 'sapdv'
-    }
-  };
-
+  // Mapping is in process and may be changed in future.
+  // Note that some mappings do share mapping - this is by design and duplicates are deduplicated during processing.
   const accessibilityFeatures = getFieldValues('dc.description.accessibilityfeature')
-    .map(feature => accessibilityFeatureMap[feature])
-    .filter(v => v);
+    .map(feature => getAccessibilityFieldInfo(feature))
+    .filter(v => v !== null);
 
-  const fields = accessibilityFeatures.reduce((prev, next) => {
-    // Do not create duplicate field if field with matching $b already exists
-    const hasMatchingField = prev.find(field => {
-      const subfieldBValues = field.subfields.filter(sf => sf.code === 'b').map(sf => sf.value);
-      return subfieldBValues.includes(next.subfieldB);
-    });
+  if (accessibilityFeatures.length === 0) {
+    return [];
+  }
 
-    if (hasMatchingField) {
+  const deduplicatedFeatures = accessibilityFeatures.reduce((prev, next) => {
+    const featureType = next.a;
+    const currentFeatures = prev[featureType];
+
+    const isDuplicate = currentFeatures.find(entry => entry === next.b);
+    if (isDuplicate) {
       return prev;
     }
 
-    // Expand $b to existing subfield if it can be done
-    const expandableFieldIdx = prev.findIndex(field => {
-      const fieldSubfieldA = field.subfields.find(sf => sf.code === 'a')?.value;
-      const fieldSubfieldB = field.subfields.find(sf => sf.code === 'b')?.value;
-      const fieldSubfield2 = field.subfields.find(sf => sf.code === '2')?.value;
-
-      const subfieldBNotMatches = fieldSubfieldB !== next.subfieldB;
-
-      const subfieldAMatches = fieldSubfieldA === next.subfieldA;
-      const subfield2Matches = fieldSubfield2 === next.subfield2;
-      const subfieldInd1Matches = field.ind1 === next.ind1;
-
-      const matchConditions = [subfieldAMatches, subfieldBNotMatches, subfield2Matches, subfieldInd1Matches];
-      return matchConditions.every(matchCondition => matchCondition === true);
-    });
-
-    if (expandableFieldIdx !== -1) {
-      const expandableField = prev[expandableFieldIdx];
-
-      // Done to keep subfield ordering intact
-      const expandableSubfieldsA = expandableField.subfields.filter(sf => sf.code === 'a');
-      const expandableSubfieldsB = expandableField.subfields.filter(sf => sf.code === 'b');
-      const expandableSubfields2 = expandableField.subfields.filter(sf => sf.code === '2');
-
-      expandableField.subfields = [
-        ...expandableSubfieldsA,
-        ...expandableSubfieldsB,
-        {code: 'b', value: next.subfieldB},
-        ...expandableSubfields2
-      ];
-
-      return prev;
-    }
-
-    return [
+    const newFeatures = currentFeatures.concat(next.b);
+    return {
       ...prev,
-      {
-        tag: '341', ind1: next.ind1,
-        subfields: [
-          {code: 'a', value: next.subfieldA},
-          {code: 'b', value: next.subfieldB},
-          {code: '2', value: next.subfield2}
-        ]
-      }
-    ];
-  }, []);
+      [featureType]: newFeatures
+    };
+  }, {auditory: [], visual: [], textual: []});
+
+  const featuresWithValues = Object.keys(deduplicatedFeatures).filter(f => deduplicatedFeatures[f].length > 0);
+
+  // Each feature type has its own field and contains deduplicated features associated with the type in $b
+  const fields = featuresWithValues.map(feature => {
+    const subfieldBs = deduplicatedFeatures[feature].map(v => ({code: 'b', value: v}));
+
+    return {
+      tag: '341', ind1: '0',
+      subfields: [
+        {code: 'a', value: feature},
+        ...subfieldBs,
+        {code: '2', value: 'sapdv'}
+      ]
+    };
+  });
 
   return fields;
 }

--- a/src/transform/convert/util/accessibility-feature-map.js
+++ b/src/transform/convert/util/accessibility-feature-map.js
@@ -1,0 +1,93 @@
+export function getAccessibilityFieldInfo(accessibilityTerm) {
+  const structuralNavigationTerms = [
+    'otsikkotasot koodimerkitty',
+    'rubriknivåer taggade',
+    'heading levels tagged'
+  ];
+
+  const alternativeTextTerms = [
+    'kuvilla vaihtoehtoiset kuvaukset',
+    'alternativa textuella beskrivningar för bilder',
+    'alternative textual descriptions for images'
+  ];
+
+  const readingOrderTerms = [
+    'looginen lukemisjärjestys',
+    'logisk läsordning',
+    'logical reading order'
+  ];
+
+  const mathMlTerms = [
+    'mathML',
+  ];
+
+  const mathDescribedTerms = [
+    'matemaattiset kaavat kuvailtu',
+    'matematiska formler beskrivna',
+    'mathematical formulas described'
+  ];
+
+  const captionsTerms = [
+    'tekstitys kuulovammaisille',
+    'textning för hörselskadade',
+    'captions for hearing impaired'
+  ];
+
+  const taggedPdfTerms = [
+    'koodimerkitty PDF',
+    'taggad PDF',
+    'tagged PDF'
+  ];
+
+  const unknownAccessibilityTerms = [
+    'ei tietoa saavutettavuudesta',
+    'okänd tillgänglighet',
+    'unknown accessibility'
+  ];
+
+  if (structuralNavigationTerms.includes(accessibilityTerm)) {
+    return {a: 'textual', b: 'structuralNavigation'};
+  }
+
+  if (alternativeTextTerms.includes(accessibilityTerm)) {
+    return {a: 'visual', b: 'alternativeText'};
+  }
+
+  if (readingOrderTerms.includes(accessibilityTerm)) {
+    return {a: 'textual', b: 'readingOrder'};
+  }
+
+  if (mathMlTerms.includes(accessibilityTerm)) {
+    return {a: 'textual', b: 'MathML'};
+  }
+
+  if (mathDescribedTerms.includes(accessibilityTerm)) {
+    return {a: 'textual', b: 'describedMath'};
+  }
+
+  if (captionsTerms.includes(accessibilityTerm)) {
+    return {a: 'auditory', b: 'openCaptions'};
+  }
+
+  if (taggedPdfTerms.includes(accessibilityTerm)) {
+    return {a: 'textual', b: 'taggedPDF'};
+  }
+
+  if (unknownAccessibilityTerms.includes(accessibilityTerm)) {
+    return {a: 'textual', b: 'unknown'};
+  }
+
+  // Note: these will be deprecated in future
+  const navigationTerms = ['navigointi mahdollista'];
+  const tableTerms = ['taulukot saavutettavia'];
+
+  if (navigationTerms.includes(accessibilityTerm)) {
+    return {a: 'textual', b: 'structuralNavigation'};
+  }
+
+  if (tableTerms.includes(accessibilityTerm)) {
+    return {a: 'textual', b: 'readingOrder'};
+  }
+
+  return null;
+}

--- a/src/transform/convert/util/accessibility-feature-map.test.js
+++ b/src/transform/convert/util/accessibility-feature-map.test.js
@@ -1,0 +1,192 @@
+import assert from 'node:assert';
+import {describe, it} from 'node:test';
+
+import {getAccessibilityFieldInfo} from './accessibility-feature-map.js';
+
+describe('getAccessibilityFieldInfo', () => {
+  // structuralNavigation
+  it('maps "otsikkotasot merkitty" properly', () => {
+    const input = 'otsikkotasot koodimerkitty';
+    const expected = {a: 'textual', b: 'structuralNavigation'};
+
+    const result = getAccessibilityFieldInfo(input);
+    assert.deepStrictEqual(result, expected);
+  });
+
+  it('maps "rubriknivåer taggade" properly', () => {
+    const input = 'rubriknivåer taggade';
+    const expected = {a: 'textual', b: 'structuralNavigation'};
+
+    const result = getAccessibilityFieldInfo(input);
+    assert.deepStrictEqual(result, expected);
+  });
+
+  it('maps "heading levels tagged" properly', () => {
+    const input = 'heading levels tagged';
+    const expected = {a: 'textual', b: 'structuralNavigation'};
+
+    const result = getAccessibilityFieldInfo(input);
+    assert.deepStrictEqual(result, expected);
+  });
+
+  // alternativeText
+  it('maps "kuvilla vaihtoehtoiset kuvaukset" properly', () => {
+    const input = 'kuvilla vaihtoehtoiset kuvaukset';
+    const expected = {a: 'visual', b: 'alternativeText'};
+
+    const result = getAccessibilityFieldInfo(input);
+    assert.deepStrictEqual(result, expected);
+  });
+
+  it('maps "alternativa textuella beskrivningar för bilder" properly', () => {
+    const input = 'alternativa textuella beskrivningar för bilder';
+    const expected = {a: 'visual', b: 'alternativeText'};
+
+    const result = getAccessibilityFieldInfo(input);
+    assert.deepStrictEqual(result, expected);
+  });
+
+  it('maps "alternative textual descriptions for images" properly', () => {
+    const input = 'alternative textual descriptions for images';
+    const expected = {a: 'visual', b: 'alternativeText'};
+
+    const result = getAccessibilityFieldInfo(input);
+    assert.deepStrictEqual(result, expected);
+  });
+
+  // readingOrder
+  it('maps "looginen lukemisjärjestys" properly', () => {
+    const input = 'looginen lukemisjärjestys';
+    const expected = {a: 'textual', b: 'readingOrder'};
+
+    const result = getAccessibilityFieldInfo(input);
+    assert.deepStrictEqual(result, expected);
+  });
+
+  it('maps "logisk läsordning" properly', () => {
+    const input = 'logisk läsordning';
+    const expected = {a: 'textual', b: 'readingOrder'};
+
+    const result = getAccessibilityFieldInfo(input);
+    assert.deepStrictEqual(result, expected);
+  });
+
+  it('maps "logical reading order" properly', () => {
+    const input = 'logical reading order';
+    const expected = {a: 'textual', b: 'readingOrder'};
+
+    const result = getAccessibilityFieldInfo(input);
+    assert.deepStrictEqual(result, expected);
+  });
+
+  // MathML
+  it('maps "mathML" properly', () => {
+    const input = 'mathML';
+    const expected = {a: 'textual', b: 'MathML'};
+
+    const result = getAccessibilityFieldInfo(input);
+    assert.deepStrictEqual(result, expected);
+  });
+
+  // describedMath
+  it('maps "matemaattiset kaavat kuvailtu" properly', () => {
+    const input = 'matemaattiset kaavat kuvailtu';
+    const expected = {a: 'textual', b: 'describedMath'};
+
+    const result = getAccessibilityFieldInfo(input);
+    assert.deepStrictEqual(result, expected);
+  });
+
+  it('maps "matematiska formler beskrivna" properly', () => {
+    const input = 'matematiska formler beskrivna';
+    const expected = {a: 'textual', b: 'describedMath'};
+
+    const result = getAccessibilityFieldInfo(input);
+    assert.deepStrictEqual(result, expected);
+  });
+
+  it('maps "mathematical formulas described" properly', () => {
+    const input = 'mathematical formulas described';
+    const expected = {a: 'textual', b: 'describedMath'};
+
+    const result = getAccessibilityFieldInfo(input);
+    assert.deepStrictEqual(result, expected);
+  });
+
+  // openCaptions
+  it('maps "tekstitys kuulovammaisille" properly', () => {
+    const input = 'tekstitys kuulovammaisille';
+    const expected = {a: 'auditory', b: 'openCaptions'};
+
+    const result = getAccessibilityFieldInfo(input);
+    assert.deepStrictEqual(result, expected);
+  });
+
+  it('maps "textning för hörselskadade" properly', () => {
+    const input = 'textning för hörselskadade';
+    const expected = {a: 'auditory', b: 'openCaptions'};
+
+    const result = getAccessibilityFieldInfo(input);
+    assert.deepStrictEqual(result, expected);
+  });
+
+  it('maps "captions for hearing impaired" properly', () => {
+    const input = 'captions for hearing impaired';
+    const expected = {a: 'auditory', b: 'openCaptions'};
+
+    const result = getAccessibilityFieldInfo(input);
+    assert.deepStrictEqual(result, expected);
+  });
+
+  // taggedPDF
+  it('maps "koodimerkitty PDF" properly', () => {
+    const input = 'koodimerkitty PDF';
+    const expected = {a: 'textual', b: 'taggedPDF'};
+
+    const result = getAccessibilityFieldInfo(input);
+    assert.deepStrictEqual(result, expected);
+  });
+
+  it('maps "taggad PDF" properly', () => {
+    const input = 'taggad PDF';
+    const expected = {a: 'textual', b: 'taggedPDF'};
+
+    const result = getAccessibilityFieldInfo(input);
+    assert.deepStrictEqual(result, expected);
+  });
+
+  it('maps "tagged PDF" properly', () => {
+    const input = 'tagged PDF';
+    const expected = {a: 'textual', b: 'taggedPDF'};
+
+    const result = getAccessibilityFieldInfo(input);
+    assert.deepStrictEqual(result, expected);
+  });
+
+  // unknown
+  it('maps "ei tietoa saavutettavuudesta" properly', () => {
+    const input = 'ei tietoa saavutettavuudesta';
+    const expected = {a: 'textual', b: 'unknown'};
+
+    const result = getAccessibilityFieldInfo(input);
+    assert.deepStrictEqual(result, expected);
+  });
+
+  it('maps "okänd tillgänglighet" properly', () => {
+    const input = 'okänd tillgänglighet';
+    const expected = {a: 'textual', b: 'unknown'};
+
+    const result = getAccessibilityFieldInfo(input);
+    assert.deepStrictEqual(result, expected);
+  });
+
+  it('maps "unknown accessibility" properly', () => {
+    const input = 'unknown accessibility';
+    const expected = {a: 'textual', b: 'unknown'};
+
+    const result = getAccessibilityFieldInfo(input);
+    assert.deepStrictEqual(result, expected);
+  });
+
+  // Note: terms that are to be deprecatd are not tested here but rather in old integration tests
+});

--- a/test-fixtures/transform/convert/common/generate3xx/generate341/05/input.xml
+++ b/test-fixtures/transform/convert/common/generate3xx/generate341/05/input.xml
@@ -1,4 +1,4 @@
 <kk:metadata>
-  <kk:field schema="dc" element="description" qualifier="accessibilityfeature" value="navigointi mahdollista" />
-  <kk:field schema="dc" element="description" qualifier="accessibilityfeature" value="taulukot saavutettavia" />
+  <kk:field schema="dc" element="description" qualifier="accessibilityfeature" value="mathML" />
+  <kk:field schema="dc" element="description" qualifier="accessibilityfeature" value="looginen lukemisjärjestys" />
 </kk:metadata>

--- a/test-fixtures/transform/convert/common/generate3xx/generate341/05/output.json
+++ b/test-fixtures/transform/convert/common/generate3xx/generate341/05/output.json
@@ -9,7 +9,7 @@
       },
       {
         "code": "b",
-        "value": "structuralNavigation"
+        "value": "MathML"
       },
       {
         "code": "b",

--- a/test-fixtures/transform/convert/common/generate3xx/generate341/08/input.xml
+++ b/test-fixtures/transform/convert/common/generate3xx/generate341/08/input.xml
@@ -1,6 +1,5 @@
 <kk:metadata>
-  <kk:field schema="dc" element="description" qualifier="accessibilityfeature" value="navigointi mahdollista" />
-  <kk:field schema="dc" element="description" qualifier="accessibilityfeature" value="kuvilla vaihtoehtoiset kuvaukset" />
+  <kk:field schema="dc" element="description" qualifier="accessibilityfeature" value="otsikkotasot koodimerkitty" />
   <kk:field schema="dc" element="description" qualifier="accessibilityfeature" value="looginen lukemisjärjestys" />
-  <kk:field schema="dc" element="description" qualifier="accessibilityfeature" value="taulukot saavutettavia" />
+  <kk:field schema="dc" element="description" qualifier="accessibilityfeature" value="kuvilla vaihtoehtoiset kuvaukset" />
 </kk:metadata>

--- a/test-fixtures/transform/convert/common/generate3xx/generate341/08/metadata.json
+++ b/test-fixtures/transform/convert/common/generate3xx/generate341/08/metadata.json
@@ -1,4 +1,4 @@
 {
-  "description": "Generates f341 from four dc.description.accessibilityfeature values where $b is different (produces one field, adds multiple new $b)",
+  "description": "Generates f341 from three dc.description.accessibilityfeature values where $b is different (produces two fields, adds multiple $b to one of them)",
   "only": false
 }

--- a/test-fixtures/transform/convert/common/generate3xx/generate341/08/output.json
+++ b/test-fixtures/transform/convert/common/generate3xx/generate341/08/output.json
@@ -5,15 +5,11 @@
     "subfields": [
       {
         "code": "a",
-        "value": "textual"
+        "value": "visual"
       },
       {
         "code": "b",
-        "value": "structuralNavigation"
-      },
-      {
-        "code": "b",
-        "value": "readingOrder"
+        "value": "alternativeText"
       },
       {
         "code": "2",
@@ -27,11 +23,15 @@
     "subfields": [
       {
         "code": "a",
-        "value": "visual"
+        "value": "textual"
       },
       {
         "code": "b",
-        "value": "alternativeText"
+        "value": "structuralNavigation"
+      },
+      {
+        "code": "b",
+        "value": "readingOrder"
       },
       {
         "code": "2",


### PR DESCRIPTION
* Expand accessibility term map
* Refactor f341 generator to be based on feature types and features
* Add separate tests for all accessibility terms to confirm all translations without having to make a lot of field generator tests